### PR TITLE
Add LIBKML driver to our GDAL installation, for improved KML support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,16 @@ WORKDIR $TMP
 RUN set -ex \
     && wget -qP $TMP http://download.osgeo.org/gdal/$GDAL_VERSION/gdal-$GDAL_VERSION.tar.gz \
     && tar -xf $TMP/gdal-$GDAL_VERSION.tar.gz -C $TMP \
+
+    && wget -qP $TMP http://s3.amazonaws.com/etc-data.koordinates.com/gdal-travisci/install-libkml-r864-64bit.tar.gz \
+    && tar -xzf $TMP/install-libkml-r864-64bit.tar.gz -C $TMP \
+
+
+    && cp -r $TMP/install-libkml/include/* /usr/local/include \
+    && cp -r $TMP/install-libkml/lib/* /usr/local/lib \
+
     && cd $TMP/gdal-$GDAL_VERSION \
-    && ./configure --with-python \
+    && ./configure --with-python --with-libkml \
     && make \
     && make install \
     && ldconfig \


### PR DESCRIPTION
A sanity check on this would be appreciated, but works on my box.

_edit:_ to verify,
`> ogrinfo --formats | grep KML`
_should return_
```
  LIBKML -vector- (rw+v): Keyhole Markup Language (LIBKML)
  KML -vector- (rw+v): Keyhole Markup Language (KML
```